### PR TITLE
Add WebAPI

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -198,7 +198,7 @@ declare module 'webuntis' {
     }
 
     export interface Inbox {
-        incomingMessages: Inboxmessage[]
+        incomingMessages: Inboxmessage[];
     }
 
     export interface Inboxmessage {
@@ -209,7 +209,7 @@ declare module 'webuntis' {
         isMessageRead: boolean;
         isReply: boolean;
         isReplyAllowed: boolean;
-        sender: Messagesender; 
+        sender: Messagesender;
         sentDateTime: string;
         subject: string;
     }
@@ -219,7 +219,64 @@ declare module 'webuntis' {
         displayName: string;
         imageUrl: string;
         className: string;
-    }        
+    }
+
+    export interface WebElement {
+        type: WebUntisElementType;
+        id: number;
+        orgId: number;
+        missing: boolean;
+        state: 'REGULAR' | 'ABSENT' | 'SUBSTITUTED';
+    }
+
+    export interface WebElementData extends WebElement {
+        element: {
+            type: number;
+            id: number;
+            name: string;
+            longName?: string;
+            displayname?: string;
+            alternatename?: string;
+            canViewTimetable: boolean;
+            externalKey?: string;
+            roomCapacity: number;
+        };
+    }
+
+    export interface WebAPITimetable {
+        id: number;
+        lessonId: number;
+        lessonNumber: number;
+        lessonCode: string;
+        lessonText: string;
+        periodText: string;
+        hasPeriodText: false;
+        periodInfo: string;
+        periodAttachments: [];
+        substText: string;
+        date: number;
+        startTime: number;
+        endTime: number;
+        elements: WebElement[];
+        studentGroup: string;
+        hasInfo: boolean;
+        code: number;
+        cellState: 'STANDARD' | 'SUBSTITUTION' | 'ROOMSUBSTITUTION';
+        priority: number;
+        is: {
+            roomSubstitution?: boolean;
+            substitution?: boolean;
+            standard?: boolean;
+            event: boolean;
+        };
+        roomCapacity: number;
+        studentCount: number;
+        classes: WebElementData[];
+        teachers: WebElementData[];
+        subjects: WebElementData[];
+        rooms: WebElementData[];
+        students: WebElementData[];
+    }
 
     export default class WebUntis {
         /**
@@ -255,7 +312,7 @@ declare module 'webuntis' {
         getNewsWidget(date: Date, validateSession?: boolean): Promise<NewsWidget>;
 
         getInbox(validateSession?: boolean): Promise<Inbox>;
-        
+
         private _buildCookies(): Promise<string>;
 
         private _checkAnonymous(): void;
@@ -304,6 +361,14 @@ declare module 'webuntis' {
             validateSession?: boolean
         ): Promise<Array<Exam>>;
 
+        getTimetableForWeek(
+            date: Date,
+            id: number,
+            type: number,
+            formatId: 1 | 2 = 1,
+            validateSession?: boolean
+        ): Promise<WebAPITimetable[]>;
+
         getTeachers(validateSession?: boolean): Promise<Teacher[]>;
 
         getStudents(validateSession?: boolean): Promise<Student[]>;
@@ -347,12 +412,7 @@ declare module 'webuntis' {
          * @augments WebUntis
          * @constructor
          */
-         constructor(
-            school: string,
-            baseurl: string,
-            identity?: string,
-            disableUserAgent?: boolean
-        );
+        constructor(school: string, baseurl: string, identity?: string, disableUserAgent?: boolean);
     }
 
     export class WebUntisSecretAuth extends WebUntis {

--- a/index.js
+++ b/index.js
@@ -150,11 +150,11 @@ class WebUntis {
         return response.data.data;
     }
 
-    
+
     /**
      * Get Inbox
      * @returns {Promise<Object>}
-     */    
+     */
     async getInbox(validateSession = true) {
         this._checkAnonymous();
         if (validateSession && !(await this.validateSession())) throw new Error('Current Session is not valid');
@@ -193,8 +193,8 @@ class WebUntis {
     /**
      * Get JWT Token
      * @returns {Promise<String>}
-     */    
-     async _getJWT(validateSession = true) {
+     */
+    async _getJWT(validateSession = true) {
         if (validateSession && !(await this.validateSession())) throw new Error('Current Session is not valid');
         const response = await this.axios({
             method: 'GET',
@@ -535,6 +535,59 @@ class WebUntis {
         if (typeof response.data.data !== 'object') throw new Error('Server returned invalid data.');
         if (!response.data.data['exams']) throw new Error("Data object doesn't contains exams object.");
         return response.data.data['exams'];
+    }
+
+    /**
+     * Get the timetable for the current week for a specific element from the web client API.
+     * @param {number} id element id
+     * @param {WebUntisElementType} type element type
+     * @param {Date} date one date in the week to query
+     * @param {Number} [formatId=1] set to 1 to include teachers, 2 to omit teachers in elements response
+     * @param {Boolean} [validateSession=true]
+     * @returns {Promise<Array>}
+     */
+    async getTimetableForWeek(id, type, date, formatId = 1, validateSession = true) {
+        if (validateSession && !(await this.validateSession())) throw new Error('Current Session is not valid');
+
+        const response = await this.axios({
+            method: 'GET',
+            url: `/WebUntis/api/public/timetable/weekly/data`,
+            params: {
+                elementType: type,
+                elementId: id,
+                date: date,
+                formatId: formatId
+            },
+            headers: {
+                Cookie: this._buildCookies(),
+            },
+        });
+
+        if (typeof response.data.data !== 'object') throw new Error('Server returned invalid data.');
+        if (!response.data.data.result || !response.data.data.result.data || !response.data.data.result.data.elementPeriods || !response.data.data.result.data.elementPeriods[id])
+            throw new Error("Invalid response");
+
+        const data = response.data.data.result.data;
+
+        const formatElements = (elements, { byType }) => {
+            const filteredElements = elements.filter((element) => element.type === byType);
+
+            return filteredElements.map(element => ({
+                ...element,
+                element: data.elements.find(dataElement => dataElement.type === byType && dataElement.id === element.id)
+            }));
+        }
+
+        const timetable = data.elementPeriods[id].map((lesson) => ({
+            ...lesson,
+            classes: formatElements(lesson.elements, { byType: WebUntis.TYPES.CLASS }),
+            teachers: formatElements(lesson.elements, { byType: WebUntis.TYPES.TEACHER }),
+            subjects: formatElements(lesson.elements, { byType: WebUntis.TYPES.SUBJECT }),
+            rooms: formatElements(lesson.elements, { byType: WebUntis.TYPES.ROOM }),
+            students: formatElements(lesson.elements, { byType: WebUntis.TYPES.STUDENT }),
+        }));
+
+        return timetable;
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const CookieBuilder = require('cookie');
 const Base64 = require('./Base64');
 const find = require('lodash.find');
-const { parse, startOfDay } = require('date-fns');
+const { parse, startOfDay, format } = require('date-fns');
 
 /**
  * WebUntis API Class
@@ -539,14 +539,14 @@ class WebUntis {
 
     /**
      * Get the timetable for the current week for a specific element from the web client API.
+     * @param {Date} date one date in the week to query
      * @param {number} id element id
      * @param {WebUntisElementType} type element type
-     * @param {Date} date one date in the week to query
-     * @param {Number} [formatId=1] set to 1 to include teachers, 2 to omit teachers in elements response
+     * @param {Number} [formatId=1] set to 1 to include teachers, 2 omits the teachers in elements response
      * @param {Boolean} [validateSession=true]
-     * @returns {Promise<Array>}
+     * @returns {Promise<WebAPITimetable[]>}
      */
-    async getTimetableForWeek(id, type, date, formatId = 1, validateSession = true) {
+    async getTimetableForWeek(date, id, type, formatId = 1, validateSession = true) {
         if (validateSession && !(await this.validateSession())) throw new Error('Current Session is not valid');
 
         const response = await this.axios({
@@ -555,7 +555,7 @@ class WebUntis {
             params: {
                 elementType: type,
                 elementId: id,
-                date: date,
+                date: format(date, "yyyy-MM-dd"),
                 formatId: formatId
             },
             headers: {


### PR DESCRIPTION
This PR adds the in #68 suggested method to query the timetable like the [WebClient](https://webuntis.com) do. While implementing that I had a few thoughts.

1. What about restructuring that libary into different files instead of one big file.
2. While mixing the "official" API (the documented one) with the WebAPI, things get complicated to understand. I mean, which function uses which API, which function should I choose as a user of that libary. So I suggest moving the WebAPI into a separate Class that is accessible through `untis.webapi.getTimetable(...)`.
