### PR TITLE
Holiday returns a number instead of Date

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -139,8 +139,8 @@ declare module 'webuntis' {
         name: string;
         longName: string;
         id: number;
-        startDate: Date;
-        endDate: Date;
+        startDate: number;
+        endDate: number;
     }
 
     export interface StatusData {


### PR DESCRIPTION
The WebUntis api returns a date in format of number (e.g. 20220404) instead of date. Can be manually changed after using `convertUntisDate`.