### PR TITLE
Fix convertUntisTime if time is 0

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -527,7 +527,7 @@ export class Base {
      */
     static convertUntisTime(time: number | string, baseDate = new Date()): Date {
         if (typeof time !== 'string') time = `${time}`;
-        return parse(time, 'Hmm', baseDate);
+        return parse(time.padStart(4, "0"), 'Hmm', baseDate);
     }
 
     /**


### PR DESCRIPTION
Somehow our teachers managed to create a lesson starting from "00:00", so I get the `startTime` back as `0`. This is failing to parse. That's the reason, why I added a `padStart` which will always ensures, that the string has a length of 4.