### PR TITLE
fix: add orgname and orgid parameters to access original room of lesson

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,8 @@ export interface ShortData {
     id: number;
     name: string;
     longname: string;
+    orgname: string;
+    orgid: number;
 }
 
 export interface Lesson {

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,8 +53,8 @@ export interface ShortData {
     id: number;
     name: string;
     longname: string;
-    orgname: string;
-    orgid: number;
+    orgname?: string;
+    orgid?: number;
 }
 
 export interface Lesson {


### PR DESCRIPTION
Sometimes the room of a specific lesson is changed which looks like this on the WebUntis website:

![Screenshot from 2024-02-04 17-47-36](https://github.com/SchoolUtils/WebUntis/assets/54598714/dc81f235-2d08-4c81-b4c7-a6c273eba713)

![Screenshot from 2024-02-04 17-47-52](https://github.com/SchoolUtils/WebUntis/assets/54598714/7b8a3dad-8b42-4007-8460-5813b977e959)

In this example the lesson is in the room "OG2-3" instead of "EG-2". The WebUntis API does add two parameters to the room object of the lesson so it looks like:

```js
{
      id: 130,
      name: 'OG2-DV1',
      longname: 'DV-Raum 1',
      orgid: 72,
      orgname: 'EG-1'
}
```

This PR adds the `orgid` and the `orgname` parameter to the `ShortData` object, that it is easy to access the original room where the lesson normally would be.
