### PR TITLE
Add missing attributes to "Klasse" interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -241,6 +241,11 @@ export interface Klasse {
     name: string;
     longName: string;
     active: boolean;
+    foreColor?: string;
+    backColor?: string;
+    did?: number;
+    teacher1?: number;
+    teacher2?: number;
 }
 
 export interface Department {


### PR DESCRIPTION
There are some optional attributes which were missing from the "Klasse" interface. See [here](https://untis-sr.ch/wp-content/uploads/2019/11/2018-09-20-WebUntis_JSON_RPC_API.pdf), page 4.