### PR TITLE
Add getCurrentSchoolyear()

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -765,6 +765,24 @@ export class Base {
     }
 
     /**
+     * Get the current school year
+     * @param [validateSession=true]
+     * @returns {Promise.<SchoolYear>}
+     */
+    async getCurrentSchoolyear(validateSession = true): Promise<SchoolYear> {
+        const data = await this._request<InternalSchoolYear>('getCurrentSchoolyear', {}, validateSession);
+
+        if (!data) throw new Error('Failed to retrieve current school year');
+
+        return {
+            name: data.name,
+            id: data.id,
+            startDate: Base.convertUntisDate(data.startDate),
+            endDate: Base.convertUntisDate(data.endDate),
+        };
+    }
+
+    /**
      * Convert a JS Date Object to a WebUntis date string
      * @param {Date} date
      * @returns {String}


### PR DESCRIPTION
Add method to retrieve current school year. See [here](https://untis-sr.ch/wp-content/uploads/2019/11/2018-09-20-WebUntis_JSON_RPC_API.pdf), page 6.