### PR TITLE
fix: ensure date-fns#parse is called with a string

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -81,7 +81,7 @@ test('should method logout return true', async () => {
 
 cases(
     'should getLatestSchoolyear return object',
-    async ({ validate }) => {
+    async ({ validate, dateFormat }) => {
         const name = 'testName';
         const id = 'testId';
         const untis = createInstance();
@@ -91,14 +91,14 @@ cases(
                 {
                     id,
                     name,
-                    startDate: '20191111',
-                    endDate: '20191211',
+                    startDate: dateFormat === 'string' ? '20191111' : 20191111,
+                    endDate: dateFormat === 'string' ? '20191211' : 20191211,
                 },
                 {
                     id,
                     name,
-                    startDate: '20191113',
-                    endDate: '20191115',
+                    startDate: dateFormat === 'string' ? '20191113' : 20191113,
+                    endDate: dateFormat === 'string' ? '20191115' : 20191115,
                 },
             ],
         });
@@ -111,8 +111,9 @@ cases(
         });
     },
     [
-        { name: 'with validate', validate: true },
-        { name: 'without validate', validate: false },
+        { name: 'with validate, string date', validate: true, dateFormat: 'string' },
+        { name: 'with validate, numeric date', validate: true, dateFormat: 'number' },
+        { name: 'without validate, string date', validate: false, dateFormat: 'string' },
     ]
 );
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,7 +1,7 @@
 import { serialize } from './cookie';
 import axios from 'axios';
 import { btoa } from './base-64';
-import { parse, startOfDay, format } from 'date-fns';
+import { parse as fnsParse, startOfDay, format, type ParseOptions } from 'date-fns';
 import type { AxiosInstance } from 'axios';
 import type {
     Absences,
@@ -24,6 +24,15 @@ import type {
 } from './types';
 import type { InternalSchoolYear, SessionInformation } from './internal';
 import { WebUntisElementType } from './types';
+
+const parse = <DateType extends Date>(
+    dateStr: string | number,
+    formatStr: string,
+    referenceDate: DateType | number | string,
+    options?: ParseOptions
+) => {
+      return fnsParse(`${dateStr}`, formatStr, referenceDate, options)
+}
 
 export class Base {
     school: string;

--- a/src/base.ts
+++ b/src/base.ts
@@ -25,6 +25,15 @@ import type {
 import type { InternalSchoolYear, SessionInformation } from './internal';
 import { WebUntisElementType } from './types';
 
+/**
+ * Ensures that the dateStr is a string when calling {@link fnsParse}.
+ * This is needed since some WebUntis servers return numbers instead of strings.
+ * @param dateStr {string | number}
+ * @param formatStr {string}
+ * @param referenceDate {DateType | number | string}
+ * @param options {ParseOptions | undefined}
+ * @returns 
+ */
 const parse = <DateType extends Date>(
     dateStr: string | number,
     formatStr: string,

--- a/src/base.ts
+++ b/src/base.ts
@@ -29,10 +29,10 @@ const parse = <DateType extends Date>(
     dateStr: string | number,
     formatStr: string,
     referenceDate: DateType | number | string,
-    options?: ParseOptions
+    options?: ParseOptions,
 ) => {
-      return fnsParse(`${dateStr}`, formatStr, referenceDate, options)
-}
+    return fnsParse(`${dateStr}`, formatStr, referenceDate, options);
+};
 
 export class Base {
     school: string;


### PR DESCRIPTION
Currently, the webuntis api of our school returns the school year as number. This creates an error when calling `parse(20240403, 'yyyyMMdd', new Date())` (from `date-fns`).

The proposed fix ensures the `parse` function of `date-fns` is called always with a string by redefining the `parse` function (which is really only a simple wrapper that transforms `dateStr` to a string).:

```ts
import { parse as fnsParse, /*...*/ type ParseOptions } from 'date-fns';
// ...
const parse = <DateType extends Date>(
    dateStr: string | number,
    formatStr: string,
    referenceDate: DateType | number | string,
    options?: ParseOptions,
) => {
    return fnsParse(`${dateStr}`, formatStr, referenceDate, options);
};
// ...
```

Thanks for having a look and btw. i like your project! Thanks :)