### PR TITLE
Added additional types to WebAPITimetable

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -191,7 +191,7 @@ export interface WebAPITimetable {
     studentGroup: string;
     hasInfo: boolean;
     code: number;
-    cellState: 'STANDARD' | 'SUBSTITUTION' | 'ROOMSUBSTITUTION';
+    cellState: 'STANDARD' | 'SUBSTITUTION' | 'ROOMSUBSTITUTION' | 'ADDITIONAL';
     priority: number;
     is: {
         roomSubstitution?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -194,6 +194,7 @@ export interface WebAPITimetable {
     cellState: 'STANDARD' | 'SUBSTITUTION' | 'ROOMSUBSTITUTION' | 'ADDITIONAL';
     priority: number;
     is: {
+        cancelled?: boolean;
         roomSubstitution?: boolean;
         substitution?: boolean;
         standard?: boolean;


### PR DESCRIPTION
Hello!
I added 'ADDITIONAL' to cellState in WebAPITimetable, because in my usage/testing with this library cellState had the Value 'ADDITIONAL' so I thought it would be better that it also would be in types.ts. cellState could also have different States other then the 4, so if there would also be a other value it would be better to set it to string instead of 4+ different strings.

This is my first Pull Request, so if I made any mistskes please tell me them!

