### PR TITLE
Add missing types and fix existing WebElementType

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -196,7 +196,7 @@ export interface WebAPITimetable {
     startTime: number;
     endTime: number;
     elements: WebElement[];
-    studentGroup: string;
+    studentGroup?: string;
     hasInfo: boolean;
     code: number;
     cellState: 'STANDARD' | 'SUBSTITUTION' | 'ROOMSUBSTITUTION' | 'ADDITIONAL' | 'EXAM' | 'CANCEL';

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,8 +167,10 @@ export interface WebElementData extends WebElement {
         longName?: string;
         displayname?: string;
         alternatename?: string;
+        foreColor?: string;
+        backColor?: string;
         canViewTimetable: boolean;
-        externalKey?: string;
+        externKey?: string;
         roomCapacity: number;
     };
 }
@@ -180,7 +182,7 @@ export interface WebAPITimetable {
     lessonCode: string;
     lessonText: string;
     periodText: string;
-    hasPeriodText: false;
+    hasPeriodText: boolean;
     periodInfo: string;
     periodAttachments: [];
     substText: string;
@@ -191,11 +193,14 @@ export interface WebAPITimetable {
     studentGroup: string;
     hasInfo: boolean;
     code: number;
-    cellState: 'STANDARD' | 'SUBSTITUTION' | 'ROOMSUBSTITUTION';
+    cellState: 'STANDARD' | 'SUBSTITUTION' | 'ROOMSUBSTITUTION' | 'ADDITIONAL' | 'CANCEL';
     priority: number;
     is: {
+        cancelled?: boolean;
         roomSubstitution?: boolean;
         substitution?: boolean;
+        shift?: boolean;
+        additional?: boolean;
         standard?: boolean;
         event: boolean;
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,7 +213,7 @@ export interface WebAPITimetable {
     };
     roomCapacity: number;
     studentCount: number;
-    debugInfo: string;
+    debugInfo?: string;
     classes: WebElementData[];
     teachers: WebElementData[];
     subjects: WebElementData[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,6 +186,12 @@ export interface WebAPITimetable {
     periodInfo: string;
     periodAttachments: [];
     substText: string;
+    exam?: {
+        markSchemaId: number;
+        name: string;
+        id: number;
+        date: number;
+    };
     date: number;
     startTime: number;
     endTime: number;
@@ -193,7 +199,7 @@ export interface WebAPITimetable {
     studentGroup: string;
     hasInfo: boolean;
     code: number;
-    cellState: 'STANDARD' | 'SUBSTITUTION' | 'ROOMSUBSTITUTION' | 'ADDITIONAL' | 'CANCEL';
+    cellState: 'STANDARD' | 'SUBSTITUTION' | 'ROOMSUBSTITUTION' | 'ADDITIONAL' | 'EXAM' | 'CANCEL';
     priority: number;
     is: {
         cancelled?: boolean;
@@ -201,11 +207,13 @@ export interface WebAPITimetable {
         substitution?: boolean;
         shift?: boolean;
         additional?: boolean;
+        exam?: boolean;
         standard?: boolean;
         event: boolean;
     };
     roomCapacity: number;
     studentCount: number;
+    debugInfo: string;
     classes: WebElementData[];
     teachers: WebElementData[];
     subjects: WebElementData[];


### PR DESCRIPTION
Hello,
I have been working with the API and found some types for data that are returned by the API but are missing from the WebAPITimetable interface. And dont found any documentation for the WebUntis API, so I dont know if there still types missing.